### PR TITLE
fix(ci): add Node.js setup and dependency installation to agent workflow

### DIFF
--- a/.github/workflows/oc standarizer.yml
+++ b/.github/workflows/oc standarizer.yml
@@ -64,6 +64,16 @@ jobs:
           fi
           echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: |
+          npm install
+
       - name: Verify OpenCode Installation
         run: |
           opencode --version || (echo "OpenCode installation failed" && exit 1)


### PR DESCRIPTION
## Summary
- Add Node.js setup step before running OpenCode agent
- Install npm dependencies to ensure Next.js/Jest/TypeScript work
- Fixes workflow failures where commands were not found

## Root Cause
The oc standarizer workflow was failing because it tried to run npm scripts (next build, jest, tsc) without installing Node.js dependencies first.

## Fix
- Added GitHub Actions setup-node step 
- Added npm install before running OpenCode agent
- Ensures all command-line tools are available

## Testing
- Verified build works after dependencies installed
- Verified Jest tests pass
- Confirms TypeScript compilation works

Resolves #65