### PR TITLE
fix: add missing database scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "typecheck": "tsc --noEmit",
     "typecheck:clean": "rm -rf .next && npm run build && tsc --noEmit",
     "optimize-db": "npx tsx scripts/optimize-database.ts",
+    "optimize-db": "npx tsx scripts/optimize-database.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
     "infrastructure:check": "./scripts/infrastructure-health-monitor.sh check",
     "infrastructure:recover": "./scripts/infrastructure-health-monitor.sh",
     "infrastructure:report": "./scripts/infrastructure-health-monitor.sh report"


### PR DESCRIPTION
## Summary
- Adds missing database scripts (`db:generate`, `db:migrate`, `db:push`, `db:studio`) to package.json
- Resolves documentation discrepancy where README.md references non-existent scripts
- Improves developer onboarding experience

## Changes
- Added 4 database management scripts using drizzle-kit
- Scripts are consistent with existing drizzle.config.ts setup
- All scripts use the same drizzle-kit package already installed as dev dependency

## Testing
- Verified drizzle-kit commands are available and functional
- Scripts match standard drizzle-orm workflow patterns
- No breaking changes to existing functionality

Fixes #84