### PR TITLE
fix: remove duplicate npm script entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "typecheck": "tsc --noEmit",
     "typecheck:clean": "rm -rf .next && npm run build && tsc --noEmit",
     "optimize-db": "npx tsx scripts/optimize-database.ts",
-    "optimize-db": "npx tsx scripts/optimize-database.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
Fixes #86

Remove duplicate 'optimize-db' script entry from package.json (lines 21-22). This improves repository hygiene and eliminates potential confusion when running npm scripts.

**Changes:**
- Removed duplicate  script entry
- Verified build passes and all tests succeed
- No functional changes to behavior