### PR TITLE
fix(types): resolve StatusType inconsistency in service layer interfaces

### DIFF
--- a/lib/services/service-types.ts
+++ b/lib/services/service-types.ts
@@ -27,12 +27,12 @@ export type StatusType = "healthy" | "degraded" | "unhealthy" | "unknown";
 // =============================================================================
 
 export interface SystemHealth {
-  status: "healthy" | "degraded" | "unhealthy";
+  status: StatusType;
   timestamp: string;
   uptime: number;
   checks: Array<{
     service: string;
-    status: "healthy" | "degraded" | "unhealthy";
+    status: StatusType;
     responseTime?: number;
     error?: string;
   }>;
@@ -81,7 +81,7 @@ export interface HealthScoreMetrics {
 
 export interface ServiceStatusData {
   name: string;
-  status: "healthy" | "degraded" | "unhealthy";
+  status: StatusType;
   responseTime?: number;
   error?: string;
   lastChecked: Date;


### PR DESCRIPTION
## Summary
- **Fixes P1 Issue #238**: Type consistency across service layer interfaces
- **Impact**: Resolves type safety issues where monitoring components return 'unknown' status but service interfaces only accepted 3-status unions
- **Files Changed**: `lib/services/service-types.ts` (3 critical interface updates)

## Technical Changes

### Interface Updates
1. **SystemHealth.status**: `"healthy" | "degraded" | "unhealthy"` → `StatusType`
2. **SystemHealth.checks[].status**: `"healthy" | "degraded" | "unhealthy"` → `StatusType`  
3. **ServiceStatusData.status**: `"healthy" | "degraded" | "unhealthy"` → `StatusType`

### Root Cause Resolution
Monitoring components in `components/monitoring/` return `"unknown"` as default status:
- `circuit-breaker-status-panel.tsx`: `getStatusType()` & `getOverallStatus()`
- `predictive-analytics-panel.tsx`: `getUrgencyStatus()` & `getSeverityStatus()`

## Verification
- ✅ TypeScript compilation: 0 errors
- ✅ Build system: Successful
- ✅ Test suite: All tests passing
- ✅ Type Safety: Eliminates runtime type mismatches

## Business Impact
- **Code Quality**: Improves type safety and maintainability
- **Developer Experience**: Consistent status handling across monitoring system
- **Reliability**: Prevents potential runtime type errors

Fixes #238