### PR TITLE
fix(security): Add validation for parseInt in Stripe webhook handler

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -54,9 +54,19 @@ export async function POST(req: NextRequest) {
             .limit(1);
 
           if (userRecord) {
-            // Add credits to user account
-            const creditsToAdd = parseInt(metadata.creditsAdded);
-              await database
+            // Add credits to user account with validation
+            const creditsToAdd = parseInt(metadata.creditsAdded, 10);
+            if (isNaN(creditsToAdd) || creditsToAdd <= 0) {
+              logger.error("Invalid credits amount in metadata", {
+                requestId: context.requestId,
+                userId: metadata.userId,
+                creditsToAdd: metadata.creditsAdded,
+                paymentIntent: event.data.object.id,
+              });
+              return; // Skip this webhook processing
+            }
+            
+            await database
                .update(users)
                .set({
                  credits: userRecord.credits + creditsToAdd,


### PR DESCRIPTION
## Summary
- Add NaN and positive validation for creditsToAdd at parse time
- Add comprehensive error logging with requestId, userId, and paymentIntent  
- Prevent potential credit balance corruption from invalid webhook metadata
- Return early if validation fails to skip processing

## Security Fix
Fixed potential data corruption where `parseInt()` on invalid metadata could return `NaN`, corrupting user credit balances.

## Changes
- **File**: `app/api/webhooks/stripe/route.ts:58-68`
- **Validation**: Added `isNaN(creditsToAdd) || creditsToAdd <= 0` check
- **Logging**: Added comprehensive error logging for debugging
- **Safety**: Early return to prevent invalid processing

## Testing
- ✅ Build passes (44.0s compilation)
- ✅ All Stripe-related tests pass (33/33 tests)
- ✅ No regressions detected

Fixes #257