### PR TITLE
fix(security): remove env import from client component to prevent leaking server secrets

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import { DashboardCard } from "@/components/ui/dashboard-card";
 import { StatsCard } from "@/components/ui/stats-card";
 import { DashboardDataService } from "@/lib/services/dashboard-data-service";
 import { logger } from "@/lib/logger";
-import { env } from "@/lib/env";
 
 interface UserCredits {
   credits: number;
@@ -15,9 +14,9 @@ interface UserCredits {
 
 // GITHUB ISSUE #343 FIX: Custom hook with safe CI fallback
 function useUserSafe() {
-  const isBuildEnv = (typeof window === 'undefined' && 
-                     typeof process !== 'undefined' && 
-                     env.NODE_ENV === 'production' && 
+  const isBuildEnv = (typeof window === 'undefined' &&
+                     typeof process !== 'undefined' &&
+                     process.env.NODE_ENV === 'production' &&
                      process.env.CI === 'true');
   
   // In CI environment, return hardcoded values without using Clerk hooks


### PR DESCRIPTION
## Summary

**P0 Critical Security Fix**: Removes env module import from client component to prevent server secrets from being exposed in client-side JavaScript bundle.

## Problem

The `app/dashboard/page.tsx` file is a client component that imported `{ env } from "@/lib/env"`. This creates a critical security vulnerability because:

1. **Security Risk**: Importing `lib/env.ts` in a client component includes ALL server environment variables (including secrets) in client-side JavaScript bundle
2. **Runtime Crash**: The env module expects server-side environment variables, which won't exist in browser, causing Zod validation to fail

## Changes

- Removed `import { env } from "@/lib/env"` from `app/dashboard/page.tsx`
- Replaced `env.NODE_ENV` with `process.env.NODE_ENV` directly (line 20)
- Only used for CI environment detection, which is safe with `process.env`

## Security Impact

- ✅ Server secrets no longer included in client-side bundle
- ✅ Zod validation no longer fails in browser environment
- ✅ CI environment detection still works correctly

## Verification

- ✅ Security audit: 0 vulnerabilities
- ✅ Build: Production build successful
- ✅ Linting: 0 errors/warnings
- ✅ Type Safety: 0 TypeScript errors
- ✅ No env import in client components verified

Closes #414