### PR TITLE
fix(types): remove 'as any' type assertion from team selection

### DIFF
--- a/app/dashboard/teams/page.tsx
+++ b/app/dashboard/teams/page.tsx
@@ -56,7 +56,7 @@ export default function TeamsPage() {
       if (!result.success) {
         throw new Error(result.error || "Failed to update team");
       }
-      await handleTeamSelect((selectedTeam as any)!);
+      await handleTeamSelect(selectedTeam!);
     } catch (err) {
       throw err;
     }


### PR DESCRIPTION
## Summary

Removes unsafe type casting from team selection handler by replacing `(selectedTeam as any)!` with `selectedTeam!`.

## Changes

- **File**: `app/dashboard/teams/page.tsx:59`
- **Before**: `await handleTeamSelect((selectedTeam as any)!);`
- **After**: `await handleTeamSelect(selectedTeam!);`

## Rationale

- Removes `as any` type assertion which bypasses TypeScript type checking
- Uses non-null assertion instead, which is safer in this context
- Maintains type safety by relying on TypeScript's type system rather than bypassing it
- Aligns with strict TypeScript standards

## Context

The `selectedTeam` variable is typed as `Team | null`, but in the context of `handleUpdateTeam`, we can safely assume it's non-null because:
1. The function is only called when a team is selected
2. The `TeamDetails` component receives `selectedTeam` directly at line 137
3. The update API call would fail without a valid team ID

## Testing

- ✅ TypeScript compilation: No errors
- ✅ ESLint: No warnings or errors
- ✅ Teams API tests: 2/2 passing

## Issue

Closes #420

---

**Priority**: P3 (Low)
**Category**: bug (type safety)
**Estimated Effort**: <1 hour