### PR TITLE
refactor(types): replace 'any' with proper ActivityFilterOptions interface in API activity routes

### DIFF
--- a/app/api/activity/feed/route.ts
+++ b/app/api/activity/feed/route.ts
@@ -3,6 +3,7 @@ import { APIRouteHandler } from "@/lib/services/api-route-handler";
 import { ActivityFeedService } from "@/lib/services/activity-feed-service";
 import { RateLimiters } from "@/lib/rate-limit-config";
 import { logger } from "@/lib/logger";
+import type { ActivityFilterOptions } from "@/lib/services/activity-feed-service";
 
 const ActivityQuerySchema = z.object({
   limit: z.coerce.number().min(1).max(100).optional().default(50),
@@ -19,7 +20,7 @@ export const GET = APIRouteHandler.createGETHandler({
     const queryParams = Object.fromEntries(req.nextUrl.searchParams);
     const validatedQuery = ActivityQuerySchema.parse(queryParams);
 
-    const options: any = {
+    const options: ActivityFilterOptions = {
       limit: validatedQuery.limit,
       offset: validatedQuery.offset,
     };

--- a/app/api/projects/[id]/activity/route.ts
+++ b/app/api/projects/[id]/activity/route.ts
@@ -5,6 +5,7 @@ import { ActivityFeedService } from "@/lib/services/activity-feed-service";
 import { ProjectDataService } from "@/lib/services/project-data-service";
 import { RateLimiters } from "@/lib/rate-limit-config";
 import { logger } from "@/lib/logger";
+import type { ActivityFilterOptions } from "@/lib/services/activity-feed-service";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -33,7 +34,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
         user!.clerkId,
       );
 
-      const options: any = {
+      const options: ActivityFilterOptions = {
         limit: validatedQuery.limit,
         offset: validatedQuery.offset,
       };

--- a/app/api/teams/[id]/activity/route.ts
+++ b/app/api/teams/[id]/activity/route.ts
@@ -5,6 +5,7 @@ import { ActivityFeedService } from "@/lib/services/activity-feed-service";
 import { teamService } from "@/lib/services/team-service";
 import { RateLimiters } from "@/lib/rate-limit-config";
 import { logger } from "@/lib/logger";
+import type { ActivityFilterOptions } from "@/lib/services/activity-feed-service";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
       const team = await teamService.getTeamById(id, user!.id);
 
-      const options: any = {
+      const options: ActivityFilterOptions = {
         limit: validatedQuery.limit,
         offset: validatedQuery.offset,
       };


### PR DESCRIPTION
## Summary

Replaces `any` type annotations with proper `ActivityFilterOptions` interface in 3 API activity routes to improve type safety.

## Changes

- Import `ActivityFilterOptions` type from `@/lib/services/activity-feed-service`
- Replace `const options: any = {...}` with `const options: ActivityFilterOptions = {...}` in:
  - `app/api/projects/[id]/activity/route.ts`
  - `app/api/teams/[id]/activity/route.ts`
  - `app/api/activity/feed/route.ts`

## Impact

✅ **Type Safety**: Eliminates loss of type safety in API routes
✅ **IDE Support**: Enables compile-time verification and autocomplete suggestions
✅ **Risk Reduction**: Prevents runtime errors from typos or incorrect property names
✅ **Zero Breaking Changes**: The types already match the expected interface

## Quality Gates

✅ TypeScript compilation: No errors
✅ ESLint: 0 warnings or errors
✅ Test Suite: 65/65 suites passing, 1071/1104 tests (97%, 33 todo)

## Related Issues

Fixes #460