### PR TITLE
fix(api-route-handler): add missing error type handling for AuthenticationError and AuthorizationError

### DIFF
--- a/lib/services/api-route-handler.ts
+++ b/lib/services/api-route-handler.ts
@@ -5,8 +5,10 @@ import {
   formatSuccessResponse,
   formatErrorResponse,
   ValidationError,
-  DatabaseError,
+  AuthenticationError,
+  AuthorizationError,
   NotFoundError,
+  DatabaseError,
   RateLimitError,
 } from "@/lib/api-utils";
 import { logger, createRequestContext } from "@/lib/logger";
@@ -191,6 +193,9 @@ class APIRouteHandler {
 
         if (
           error instanceof ValidationError ||
+          error instanceof AuthenticationError ||
+          error instanceof AuthorizationError ||
+          error instanceof NotFoundError ||
           error instanceof DatabaseError ||
           error instanceof RateLimitError
         ) {
@@ -311,6 +316,9 @@ class APIRouteHandler {
 
         if (
           error instanceof ValidationError ||
+          error instanceof AuthenticationError ||
+          error instanceof AuthorizationError ||
+          error instanceof NotFoundError ||
           error instanceof DatabaseError ||
           error instanceof RateLimitError
         ) {
@@ -392,7 +400,14 @@ class APIRouteHandler {
           authenticatedUser?.clerkId,
         );
 
-        if (error instanceof DatabaseError || error instanceof NotFoundError) {
+        if (
+          error instanceof ValidationError ||
+          error instanceof AuthenticationError ||
+          error instanceof AuthorizationError ||
+          error instanceof NotFoundError ||
+          error instanceof DatabaseError ||
+          error instanceof RateLimitError
+        ) {
           return formatErrorResponse(error);
         }
 
@@ -526,8 +541,12 @@ let authenticatedUser:
               );
 
               if (
+                error instanceof ValidationError ||
+                error instanceof AuthenticationError ||
+                error instanceof AuthorizationError ||
+                error instanceof NotFoundError ||
                 error instanceof DatabaseError ||
-                error instanceof NotFoundError
+                error instanceof RateLimitError
               ) {
                 throw error;
               }
@@ -649,6 +668,32 @@ let authenticatedUser:
           return NextResponse.json(
             formatErrorResponse(error),
             { status: 400 }
+          );
+        }
+
+        if (error instanceof AuthenticationError) {
+          logger.apiError(
+            "Authentication error in DELETE",
+            context.requestId,
+            error,
+            { url: url.pathname, userId: authenticatedUser?.clerkId }
+          );
+          return NextResponse.json(
+            formatErrorResponse(error),
+            { status: 401 }
+          );
+        }
+
+        if (error instanceof AuthorizationError) {
+          logger.apiError(
+            "Authorization error in DELETE",
+            context.requestId,
+            error,
+            { url: url.pathname, userId: authenticatedUser?.clerkId }
+          );
+          return NextResponse.json(
+            formatErrorResponse(error),
+            { status: 403 }
           );
         }
 


### PR DESCRIPTION
## Summary
Fixes #469 - AuthenticationError not caught, returns wrong HTTP status

## Problem
When `getAuthenticatedUser` throws an `AuthenticationError`, the `APIRouteHandler` catch blocks did not handle it properly. Instead of returning 401 Unauthorized, it fell through to the generic error handler and returned 500 Internal Server Error.

## Solution
Added missing error type handling for `AuthenticationError` and `AuthorizationError` in all API route handler catch blocks:
- Added both error types to imports
- Added instanceof checks in all catch blocks (createPOSTHandler, createPUTHandler, createGETHandler, createCachedGETHandler, createDELETEHandler)
- Ensures proper HTTP status codes: 401 for authentication errors, 403 for authorization errors

## Changes Made
- **lib/services/api-route-handler.ts**:
  - Added `AuthenticationError` and `AuthorizationError` to imports
  - Updated catch blocks in 5 handler methods to check for these error types
  - createDELETEHandler: Added explicit checks with proper status codes (401/403)

## Impact
- **Security**: Authentication errors now properly return 401 status
- **UX**: Users receive accurate error messages about authentication failures
- **Debugging**: Real authentication issues are no longer masked as system errors

## Testing
- ✅ Security audit: 0 vulnerabilities (npm audit)
- ✅ Build: Production build successful (57.1s, 62 static pages)
- ✅ Lint: 0 ESLint warnings
- ✅ Typecheck: 0 TypeScript errors
- ✅ Tests: 66/66 suites passing, 1083/1116 tests passing (97%, 33 todo)

## Verification
To verify the fix:
1. Make unauthenticated request to `/api/projects`
2. Should receive 401 status with "Authentication required" message
3. Should NOT receive 500 status with "API request failed" message