### PR TITLE
refactor(types): replace 'any' type in BlueprintRefinementContext.marketResearch

### DIFF
--- a/lib/services/blueprint-refinement-service.ts
+++ b/lib/services/blueprint-refinement-service.ts
@@ -7,6 +7,7 @@ import {
 import type {
   BlueprintData,
 } from "./blueprint-generation-service";
+import type { ResearchResult } from "./service-types";
 import DatabaseQueryCache from "./database-cache-service";
 import { UnifiedCacheManager } from "./cache-orchestrator";
 
@@ -18,7 +19,7 @@ export interface BlueprintRefinementRequest {
 
 export interface BlueprintRefinementContext {
   currentBlueprint: BlueprintData;
-  marketResearch: any;
+  marketResearch?: ResearchResult;
   version: number;
 }
 


### PR DESCRIPTION
## Summary
- Replace `any` type with properly typed `ResearchResult?` in `BlueprintRefinementContext.marketResearch`
- Import `ResearchResult` type from `service-types.ts`
- Maintains backward compatibility with optional type

## Changes
- Added import: `import type { ResearchResult } from "./service-types"`
- Updated interface field: `marketResearch: any;` → `marketResearch?: ResearchResult;`

## Issue
Closes #483

## Testing
- ✅ TypeScript compilation: `npm run typecheck` - 0 errors
- ✅ ESLint: `npm run lint` - 0 warnings/errors
- ✅ Test suite: 68/68 suites passing, 1125/1158 tests (33 todo)

## Risk Assessment
**LOW RISK** - Simple type replacement, no logic changes