### PR TITLE
fix(team): wrap webhook/activity calls in try-catch for consistency

### DIFF
--- a/lib/services/team-service.ts
+++ b/lib/services/team-service.ts
@@ -1039,52 +1039,59 @@ class TeamService {
         teamId,
       });
 
-      // Emit webhook event
-      await WebhookEventDispatcher.emitTeamDeleted(
-        requestingUserId,
-        requestingUser.clerkId,
-        teamId,
-        team.name,
-        memberCount,
-      );
-
-      // Record activity feed event
-      await ActivityFeedService.recordActivity({
-        userId: requestingUserId,
-        clerkId: requestingUser.clerkId,
-        entityType: "team",
-        entityId: teamId,
-        eventType: "team.deleted",
-        eventData: {
-          teamName: team.name,
+      try {
+        // Emit webhook event
+        await WebhookEventDispatcher.emitTeamDeleted(
+          requestingUserId,
+          requestingUser.clerkId,
+          teamId,
+          team.name,
           memberCount,
-        },
-      });
+        );
 
-      // Send notifications to all team members (except deleter)
-      for (const member of teamMembersList) {
-        if (member.clerkId !== requestingUser.clerkId) {
-          try {
-            await NotificationService.dispatch(
-              member.clerkId,
-              "team_deleted",
-              "Team Deleted",
-              `Team "${team.name}" has been deleted by ${requestingUser.email}`,
-              {
+        // Record activity feed event
+        await ActivityFeedService.recordActivity({
+          userId: requestingUserId,
+          clerkId: requestingUser.clerkId,
+          entityType: "team",
+          entityId: teamId,
+          eventType: "team.deleted",
+          eventData: {
+            teamName: team.name,
+            memberCount,
+          },
+        });
+
+        // Send notifications to all team members (except deleter)
+        for (const member of teamMembersList) {
+          if (member.clerkId !== requestingUser.clerkId) {
+            try {
+              await NotificationService.dispatch(
+                member.clerkId,
+                "team_deleted",
+                "Team Deleted",
+                `Team "${team.name}" has been deleted by ${requestingUser.email}`,
+                {
+                  teamId,
+                  teamName: team.name,
+                  deletedBy: requestingUser.email,
+                },
+                undefined,
+              );
+            } catch (notificationError) {
+              logger.error("Failed to send team deletion notification", {
                 teamId,
-                teamName: team.name,
-                deletedBy: requestingUser.email,
-              },
-              undefined,
-            );
-          } catch (notificationError) {
-            logger.error("Failed to send team deletion notification", {
-              teamId,
-              targetClerkId: member.clerkId,
-              error: notificationError instanceof Error ? notificationError.message : String(notificationError),
-            });
+                targetClerkId: member.clerkId,
+                error: notificationError instanceof Error ? notificationError.message : String(notificationError),
+              });
+            }
           }
         }
+      } catch (activityError) {
+        logger.error("Failed to record team.deleted activity", {
+          teamId,
+          error: activityError instanceof Error ? activityError.message : String(activityError),
+        });
       }
     } catch (error) {
       logger.error("Failed to delete team", {


### PR DESCRIPTION
## Summary

This PR addresses a code quality issue introduced in #502 where webhook, activity feed, and notification calls in the `deleteTeam` method were not wrapped in a try-catch block, making it inconsistent with other team service methods.

## Problem

The `deleteTeam` method (introduced in #502) calls `WebhookEventDispatcher.emitTeamDeleted`, `ActivityFeedService.recordActivity`, and `NotificationService.dispatch` without error handling. This is inconsistent with other methods in the file:

- `createTeam` (lines 127-158): Has try-catch around webhook/activity
- `inviteTeamMember` (lines 425-482): Has try-catch around webhook/activity
- `updateTeamMemberRole` (lines 566-639): Has try-catch around webhook/activity
- `removeTeamMember` (lines 728-797): Has try-catch around webhook/activity

## Solution

Wrap the webhook, activity feed, and notification calls in a try-catch block with appropriate error logging, consistent with the established pattern in the codebase.

## Impact

- **Code Quality**: Improves consistency with existing patterns
- **Error Handling**: Ensures webhook/activity recording failures don't cause confusion
- **Maintainability**: Makes the codebase more maintainable by following established conventions

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint checks pass (0 warnings/errors)
- ✅ All tests pass (13/13 team-service tests)
- ✅ No breaking changes to existing functionality

## Related

Follow-up to #502 (merged)