### PR TITLE
fix(test): update verification test metrics to match current AGENTS.md

### DIFF
--- a/__tests__/issue-178-fix-verification.test.ts
+++ b/__tests__/issue-178-fix-verification.test.ts
@@ -32,7 +32,7 @@ describe('Issue #178 - AGENTS.md Quality Gate Metrics', () => {
     
     // Should have current metrics
     expect(buildInfo).toContain('62 static pages');
-    expect(buildInfo).toContain('53s compile time');
+    expect(buildInfo).toContain('16.9s compile time');
     
     // Should not have outdated metrics
     expect(buildInfo).not.toContain('25.5s');
@@ -43,7 +43,7 @@ describe('Issue #178 - AGENTS.md Quality Gate Metrics', () => {
     const agentsContent = fs.readFileSync('AGENTS.md', 'utf8');
     
     // Extract test metrics
-    const testMatch = agentsContent.match(/`npm test --silent` - MUST return (\d+)% pass rate \(([^)]+)\)/);
+    const testMatch = agentsContent.match(/`npm test --silent` - MUST return (\d+\.?\d*)% pass rate \(([^)]+)\)/);
     expect(testMatch).toBeTruthy();
     
     const testInfo = testMatch[2];
@@ -60,7 +60,7 @@ describe('Issue #178 - AGENTS.md Quality Gate Metrics', () => {
     const agentsContent = fs.readFileSync('AGENTS.md', 'utf8');
     
     // Should contain recent verification date
-    expect(agentsContent).toContain('January 14, 2026 FRESH VERIFICATION');
+    expect(agentsContent).toContain('January 15, 2026 FRESH VERIFICATION');
     
     // Should not have old dates
     expect(agentsContent).not.toContain('January 12, 2026 verification');
@@ -83,6 +83,6 @@ describe('Issue #178 - AGENTS.md Quality Gate Metrics', () => {
     expect(agentsContent).toContain('MUST pass');
     expect(agentsContent).toContain('MUST return 0 warnings/errors');
     expect(agentsContent).toContain('MUST return 0 TypeScript errors');
-    expect(agentsContent).toMatch(/MUST return \d+% pass rate/);
+    expect(agentsContent).toMatch(/MUST return \d+\.?\d*% pass rate/);
   });
 });


### PR DESCRIPTION
## Summary
Updated verification test expectations in `__tests__/issue-178-fix-verification.test.ts` to match current metrics in AGENTS.md. All 68/68 test suites now pass.

## Changes
- **Build time**: Updated expectation from `'53s compile time'` to `'16.9s compile time'` (line 35)
- **Test pass rate regex**: Updated `(\d+)%` to `(\d+\.?\d*)%` to accept decimal percentages like `97.1%` (line 46)
- **Verification date**: Updated from `'January 14, 2026 FRESH VERIFICATION'` to `'January 15, 2026 FRESH VERIFICATION'` (line 63)
- **Pass rate regex**: Updated `\d+%` to `\d+\.?\d*%` to accept decimal percentages (line 86)

## Root Cause
After recent documentation updates (commit 2f9938d on January 15, 2026), AGENTS.md was updated with current metrics:
- Build time: 53s → 16.9s
- Test suites: 65/65 → 68/68
- Total tests: 1071/1104 → 1127/1160

The verification test was not updated to match these new metrics, causing false failures.

## Test Results
- ✅ All 68/68 test suites passing
- ✅ 1127/1160 tests passing (97.1%)
- ✅ Verification test now validates current AGENTS.md metrics accurately

## Fixes
Fixes #508

## Business Impact
- **Developer Experience**: Eliminates false test failures that waste development time
- **CI/CD Pipeline**: Test suite now shows green status, reflecting actual code quality
- **Onboarding**: New contributors won't be confused by outdated test expectations