### PR TITLE
fix(ci): temporarily disable on-pull workflow due to OpenCode service failure

### DIFF
--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
 
+    # TEMPORARILY DISABLED due to external OpenCode service failure
+    # See: Issue #631, #609 (original), #629 (duplicate)
+    # Re-enable when OpenCode installation service (https://opencode.ai/install) is restored
+    if: ${{ false }}
+
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       IFLOW_API_KEY: ${{ secrets.IFLOW_API_KEY }}


### PR DESCRIPTION
## Summary

Temporarily disables the `on-pull` workflow until the external OpenCode service is restored.

## Problem

The `on-pull` workflow is failing for all PRs due to external OpenCode service failure (`https://opencode.ai/install` returns "Failed to fetch version information"). This is blocking all PR merges.

## Solution

Adds `if: ${{ false }}` condition to the `on-pull` job to disable the workflow temporarily, with a comment explaining the reason and referencing related issues.

## Changes

- Added `if: ${{ false }}` condition to disable workflow
- Added detailed comment explaining:
  - Reason for disablement
  - Related issues (#631, #609, #629)
  - When to re-enable (when OpenCode service is restored)

## Acceptance Criteria

- ✅ `on-pull` workflow disabled with `if: ${{ false }}` condition
- ✅ Comment added to workflow explaining the reason and #609 reference
- ✅ Unblocks PRs while external service is down

## Related Issues

Fixes #631

---

**Impact**: Unblocks all PRs that are currently blocked by the failing OpenCode installation step.