### PR TITLE
fix(typescript): set ignoreBuildErrors to false to catch type errors in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
   transpilePackages: [],
 
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
 
 // Stable experimental features - Fix for Issue #232: Removed problematic optimizePackageImports


### PR DESCRIPTION
## Summary
Fix TypeScript build configuration to ensure type errors are caught during production builds.

## Problem
The `ignoreBuildErrors: true` setting in `next.config.js` was masking potential type errors, which could allow them to reach production without detection.

## Solution
Changed `ignoreBuildErrors: true` to `ignoreBuildErrors: false` in `next.config.js`

## Verification
- ✅ `npm run typecheck` - 0 TypeScript errors
- ✅ `npm run build` - Successful build (72.0s)
- ✅ No regressions introduced

## Impact
- **Type Safety**: Ensures all type errors are caught during builds
- **Production Quality**: Prevents type errors from reaching production
- **Alignment**: Aligns with AGENTS.md requirement for strict TypeScript compliance

## Related Issues
Closes #651